### PR TITLE
[feat] 유저 정보 수정 관련 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ HELP.md
 .gradle
 .env
 build/
+static/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ FROM openjdk:17-jdk-slim
 
 WORKDIR /app
 
+RUN mkdir -p /app/static
+
 COPY --from=builder /app/build/libs/*.jar app.jar
 
 CMD ["java", "-jar", "app.jar"]

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -3,10 +3,12 @@ version: '3.9'
 services:
   server:
     image: yaongmeow/ppu-docker:latest
+    pull_policy: always
     container_name: ppu-container
+    volumes:
+      - /home/ubuntu/static:/app/static
     ports:
       - "8080:8080"
     restart: always
     env_file:
       - ./.env
-    pull_policy: always

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -2,11 +2,17 @@ version: '3.9'
 
 services:
   server:
-    build: .
-    image: ppu-app:latest
+    build:
+      context: .
+      dockerfile: local.Dockerfile
+    image: ppu-app-local:latest
+    volumes:
+      - ./src:/app/src
+      - ./static:/app/static
     container_name: ppu-container
     ports:
       - "8080:8080"
+    command: ./gradlew bootRun
     restart: always
     env_file:
       - ./.env

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,0 +1,7 @@
+FROM openjdk:17-jdk-slim
+
+WORKDIR /app
+
+CMD mkdir static
+
+COPY . .

--- a/src/main/java/com/ppu/ppu/user/UserController.java
+++ b/src/main/java/com/ppu/ppu/user/UserController.java
@@ -1,0 +1,26 @@
+package com.ppu.ppu.user;
+
+import com.ppu.ppu.user.dto.UserNicknameUpdateDto;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PatchMapping("/nickname")
+    public ResponseEntity<Void> updateNickname(HttpServletRequest request, @RequestBody UserNicknameUpdateDto updateDto) {
+        String id = request.getAttribute("id").toString();
+        userService.updateUserNickname(id, updateDto.getNickname());
+        return ResponseEntity.noContent().build();
+    }
+
+
+
+}

--- a/src/main/java/com/ppu/ppu/user/UserController.java
+++ b/src/main/java/com/ppu/ppu/user/UserController.java
@@ -1,17 +1,24 @@
 package com.ppu.ppu.user;
 
 import com.ppu.ppu.user.dto.UserNicknameUpdateDto;
+import com.ppu.ppu.utils.FileUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/user")
 public class UserController {
     private final UserService userService;
+    private final FileUtil fileUtil;
 
-    public UserController(UserService userService) {
+    public UserController(UserService userService, FileUtil fileUtil) {
         this.userService = userService;
+        this.fileUtil = fileUtil;
     }
 
     @PatchMapping("/nickname")
@@ -21,6 +28,18 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-
-
+    @PatchMapping("/profile-img")
+    public ResponseEntity<Void> updateProfileImage(HttpServletRequest request, @RequestParam("file") MultipartFile file) {
+        String id = request.getAttribute("id").toString();
+        try {
+            Optional<String> filename = fileUtil.storeFile(file);
+            if (!filename.isPresent()) {
+                return ResponseEntity.badRequest().build();
+            }
+            userService.updateUserProfileImage(id, filename.get());
+            return ResponseEntity.noContent().build();
+        } catch (IOException e) {
+            return ResponseEntity.internalServerError().build();
+        }
+    }
 }

--- a/src/main/java/com/ppu/ppu/user/UserRepository.java
+++ b/src/main/java/com/ppu/ppu/user/UserRepository.java
@@ -1,9 +1,17 @@
 package com.ppu.ppu.user;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
+    Optional<User> findByNickname(String nickname);
+
+    @Modifying
+    @Query("UPDATE User u SET u.nickname = :nickname WHERE u.id = :id")
+    int updateNicknameById(@Param("id") String id, @Param("nickname") String nickname);
 }

--- a/src/main/java/com/ppu/ppu/user/UserRepository.java
+++ b/src/main/java/com/ppu/ppu/user/UserRepository.java
@@ -14,4 +14,8 @@ public interface UserRepository extends JpaRepository<User, String> {
     @Modifying
     @Query("UPDATE User u SET u.nickname = :nickname WHERE u.id = :id")
     int updateNicknameById(@Param("id") String id, @Param("nickname") String nickname);
+
+    @Modifying
+    @Query("UPDATE User u SET u.profileImage = :profileImage WHERE u.id = :id")
+    int updateProfileImageById(@Param("id") String id, @Param("profileImage") String filePath);
 }

--- a/src/main/java/com/ppu/ppu/user/UserService.java
+++ b/src/main/java/com/ppu/ppu/user/UserService.java
@@ -18,6 +18,9 @@ public class UserService {
     public Optional<User> getUserByEmail(String email){
         return userRepository.findByEmail(email);
     }
+    public Optional<User> getUserByNickname(String nickname){
+        return userRepository.findByNickname(nickname);
+    }
 
     @Transactional
     public void createUser(UserCreateDto user){
@@ -29,5 +32,10 @@ public class UserService {
         newUser.setBirth(user.getBirth());
         newUser.printEntity();
         userRepository.save(newUser);
+    }
+
+    @Transactional
+    public void updateUserNickname(String id, String nickname){
+        userRepository.updateNicknameById(id, nickname);
     }
 }

--- a/src/main/java/com/ppu/ppu/user/UserService.java
+++ b/src/main/java/com/ppu/ppu/user/UserService.java
@@ -38,4 +38,9 @@ public class UserService {
     public void updateUserNickname(String id, String nickname){
         userRepository.updateNicknameById(id, nickname);
     }
+
+    @Transactional
+    public void updateUserProfileImage(String id, String filePath){
+        userRepository.updateProfileImageById(id, filePath);
+    }
 }

--- a/src/main/java/com/ppu/ppu/user/dto/UserNicknameUpdateDto.java
+++ b/src/main/java/com/ppu/ppu/user/dto/UserNicknameUpdateDto.java
@@ -1,0 +1,11 @@
+package com.ppu.ppu.user.dto;
+
+public class UserNicknameUpdateDto {
+    private String nickname;
+    public String getNickname() {
+        return nickname;
+    }
+    public void setNickname(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/src/main/java/com/ppu/ppu/utils/FileUtil.java
+++ b/src/main/java/com/ppu/ppu/utils/FileUtil.java
@@ -1,0 +1,36 @@
+package com.ppu.ppu.utils;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class FileUtil {
+    @Value("${STATIC_FILE_PATH}")
+    private String filePath;
+
+    public FileUtil(){}
+
+    public String generateFileName(String originalFileName) {
+        String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+        String uniqueName = UUID.randomUUID().toString();
+        return uniqueName + extension;
+    }
+
+    public Optional<String> storeFile(MultipartFile file) throws IOException {
+        if (file.isEmpty()) {
+            return null;
+        }
+
+        String originalFilename = file.getOriginalFilename();
+        String storeFileName = generateFileName(originalFilename);
+
+        file.transferTo(new File(filePath + storeFileName));
+        return Optional.of("/static/" + storeFileName);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,8 +6,12 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASS}
     driver-class-name: org.postgresql.Driver
-
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
       ddl-auto: update
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 20MB


### PR DESCRIPTION
## 👩🏻‍💻 작업 내용
### 프로필 이미지 수정
- 정적 파일 업로드 및 접근을 위한 #8 관련 작업 진행
  - 인가 거치지 않고 파일 접근 가능한 문제 추후 해결 필요

- 컨테이너 내 /app/static에 이미지 파일 저장, 서버의 /home/ubuntu/static에 볼륨 연결

- 파일 업로드를 위한 `FileUtil` 클래스 작성
### 사용자 닉네임 수정
- 검증 없이 수정 가능하도록 구현

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 🔍 참고 사항
-  put/patch 프론트와 논의 필요

- 초기 닉네임 기획상 논의 필요

- 닉네임 중복 확인할 지 논의 필요

## 🔘 관련 이슈
- #9 

- 배포 환경 정상 동작 확인 후 close 예정 