### PR TITLE
[fix] 프로필 이미지 수정 시 기존 파일 삭제하도록 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,5 +43,7 @@ jobs:
             echo "DB_HOST=${{ secrets.DB_HOST }}" >> .env
             echo "DB_PORT=${{ secrets.DB_PORT }}" >> .env
             echo "DB_NAME=${{ secrets.DB_NAME }}" >> .env
+            echo "TOKEN_SECRET=${{ secrets.TOKEN_SECRET }}" >> .env
+            echo "DEV_TOKEN_EXP=${{ secrets.DEV_TOKEN_EXP }}" >> .env
             echo "STATIC_FILE_PATH=${{ secrets.STATIC_FILE_PATH }}" >> .env
             sudo docker-compose -f docker-compose-dev.yml up -d

--- a/src/main/java/com/ppu/ppu/user/UserController.java
+++ b/src/main/java/com/ppu/ppu/user/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     }
 
     @PatchMapping("/profile-img")
-    public ResponseEntity<Void> updateProfileImage(HttpServletRequest request, @RequestParam("file") MultipartFile file) {
+    public ResponseEntity<Void> updateProfileImage(HttpServletRequest request, @RequestParam(value = "file", required = false) MultipartFile file) {
         String id = request.getAttribute("id").toString();
         Optional<User> user = userService.findUserById(id);
         if(!user.isPresent()) {return ResponseEntity.badRequest().build();}
@@ -37,6 +37,11 @@ public class UserController {
 
         if(profileImage != null) {
             fileUtil.deleteFile(profileImage);
+        }
+
+        if(file == null) {
+            userService.updateUserProfileImage(id, null);
+            return ResponseEntity.noContent().build();
         }
 
         try {

--- a/src/main/java/com/ppu/ppu/user/UserController.java
+++ b/src/main/java/com/ppu/ppu/user/UserController.java
@@ -31,6 +31,14 @@ public class UserController {
     @PatchMapping("/profile-img")
     public ResponseEntity<Void> updateProfileImage(HttpServletRequest request, @RequestParam("file") MultipartFile file) {
         String id = request.getAttribute("id").toString();
+        Optional<User> user = userService.findUserById(id);
+        if(!user.isPresent()) {return ResponseEntity.badRequest().build();}
+        String profileImage = user.get().getProfileImage();
+
+        if(profileImage != null) {
+            fileUtil.deleteFile(profileImage);
+        }
+
         try {
             Optional<String> filename = fileUtil.storeFile(file);
             if (!filename.isPresent()) {

--- a/src/main/java/com/ppu/ppu/user/UserRepository.java
+++ b/src/main/java/com/ppu/ppu/user/UserRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
     Optional<User> findByNickname(String nickname);
+    Optional<User> findById(String id);
 
     @Modifying
     @Query("UPDATE User u SET u.nickname = :nickname WHERE u.id = :id")

--- a/src/main/java/com/ppu/ppu/user/UserService.java
+++ b/src/main/java/com/ppu/ppu/user/UserService.java
@@ -43,4 +43,8 @@ public class UserService {
     public void updateUserProfileImage(String id, String filePath){
         userRepository.updateProfileImageById(id, filePath);
     }
+
+    public Optional<User> findUserById(String id){
+        return userRepository.findById(id);
+    }
 }

--- a/src/main/java/com/ppu/ppu/utils/FileUtil.java
+++ b/src/main/java/com/ppu/ppu/utils/FileUtil.java
@@ -33,4 +33,11 @@ public class FileUtil {
         file.transferTo(new File(filePath + storeFileName));
         return Optional.of("/static/" + storeFileName);
     }
+
+    public void deleteFile(String fileName) {
+        File file = new File("/app" + fileName);
+        if (file.exists()) {
+            file.delete();
+        }
+    }
 }

--- a/src/main/java/com/ppu/ppu/utils/JwtUtil.java
+++ b/src/main/java/com/ppu/ppu/utils/JwtUtil.java
@@ -13,8 +13,8 @@ public class JwtUtil {
     private final Long exp;
 
     public JwtUtil() {
-        this.secret = "mysecretkeymysecretkeymysecretkeymysecretkeymysecretkeymysecretkey";
-        this.exp = Long.valueOf(3600000);
+        this.secret = System.getenv("TOKEN_SECRET");
+        this.exp = Long.valueOf(System.getenv("DEV_TOKEN_EXP"));
     }
 
     public String generateToken(String id) {


### PR DESCRIPTION
## 👩🏻‍💻 작업 내용
- 프로필 이미지 수정 API 호출 시 기존 이미지 확인

- 기존 이미지 있을 경우 삭제 진행

- 수정 API에 사진 파일 첨부하지 않을 경우 기존 이미지 확인, 존재할 경우 삭제만 진행

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 🔍 참고 사항
-  추후 프론트와 논의 필요

## 🔘 관련 이슈
- close #12