### PR TITLE
[fix] 배포 관련 여러 오류 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,8 +48,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: |
-            sudo docker-compose -f docker-compose-dev.yml down
-            sudo docker image prune -y
+            sudo docker compose -f docker-compose-dev.yml down
             touch .env
             echo "DB_USER=${{ secrets.DB_USER }}" > .env
             echo "DB_PASS=${{ secrets.DB_PASS }}" >> .env
@@ -63,4 +62,5 @@ jobs:
             echo "KAKAO_REST_API_KEY=${{ secrets.KAKAO_REST_API_KEY }}" >> .env
             echo "KAKAO_REDIRECT_URI=${{ secrets.KAKAO_REDIRECT_URI }}" >> .env
             echo "WITHDRAW_REDIRECT_URI=${{ secrets.WITHDRAW_REDIRECT_URI }}" >> .env
-            sudo docker-compose -f docker-compose-dev.yml up -d
+            sudo docker compose -f docker-compose-dev.yml up -d
+            sudo docker image prune -f

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # 1. build stage
-FROM eclipse-temurin:17-jdk-jammy AS builder
+#FROM eclipse-temurin:17-jdk-jammy AS builder
+FROM openjdk:17-jdk-slim AS builder
 
 WORKDIR /app
 
@@ -21,7 +22,8 @@ COPY . .
 RUN ./gradlew --no-daemon clean build -x test
 
 # 2. run stage
-FROM eclipse-temurin:17-jre-jammy AS runner
+#FROM eclipse-temurin:17-jre-jammy AS runner
+FROM openjdk:17-jdk-slim AS runner
 
 WORKDIR /app
 

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	//implementation 'org.springframework.boot:spring-boot-starter-webflux' // oauth api post
+	implementation 'org.springframework.boot:spring-boot-starter-webflux' // oauth api post
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // test invalid api dto
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' // swagger
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
+	id 'org.springframework.boot' version '3.4.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -43,7 +43,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux' // oauth api post
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // test invalid api dto
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' // swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.11' // swagger
 	developmentOnly 'org.springframework.boot:spring-boot-devtools' // 핫 리로드 용도
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.2'
+	id 'org.springframework.boot' version '3.3.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -16,6 +16,11 @@ java {
 configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
+	}
+	// 핫 리로드 용도
+	developmentOnly
+	runtimeClasspath {
+		extendsFrom developmentOnly
 	}
 }
 
@@ -39,8 +44,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux' // oauth api post
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // test invalid api dto
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0' // swagger
+	developmentOnly 'org.springframework.boot:spring-boot-devtools' // 핫 리로드 용도
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+// 핫 리로드 용도
+tasks.named('bootRun') {
+	sourceResources(sourceSets.main)
+}
+
+tasks.withType(JavaCompile) {
+	options.compilerArgs += ["-parameters"]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.3.2'
+	id 'org.springframework.boot' version '3.4.2'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -5,8 +5,6 @@ services:
     image: yaongmeow/ppu-docker:latest
     pull_policy: always
     container_name: ppu-container
-    volumes:
-      - /home/ubuntu/static:/app/static
     ports:
       - "8080:8080"
     restart: always

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -6,11 +6,19 @@ services:
       context: .
       dockerfile: local.Dockerfile
     image: ppu-app-local:latest
-    volumes:
-      - ./src:/app/src
     container_name: ppu-container
     ports:
       - "8080:8080"
+    # 핫 리로드 용도
+    volumes:
+      - .:/app
+      - ~/.gradle:/root/.gradle
     restart: always
     env_file:
       - ./.env
+    # 핫 리로드 용도
+    environment:
+      JAVA_TOOL_OPTIONS: >
+        -Dspring.devtools.restart.enabled=true
+        -Dspring.devtools.restart.poll-interval=1s
+        -Dspring.devtools.restart.quiet-period=500ms

--- a/local.Dockerfile
+++ b/local.Dockerfile
@@ -1,17 +1,11 @@
-# 1. Build Stage
-FROM gradle:8.2.0-jdk17 AS builder
+FROM openjdk:17-jdk-slim AS builder
 
 WORKDIR /app
 
-COPY . .
+COPY gradlew gradlew.bat settings.gradle build.gradle ./
 
-RUN rm -rf ~/.gradle/caches && ./gradlew clean build --no-build-cache --refresh-dependencies
+COPY gradle gradle
 
-# 2. Run Stage
-FROM openjdk:17-jdk-slim
+RUN ./gradlew --no-daemon -q dependencies
 
-WORKDIR /app
-
-COPY --from=builder /app/build/libs/*.jar app.jar
-
-CMD ["java", "-jar", "app.jar"]
+ENTRYPOINT ["./gradlew","--no-daemon","bootRun"]

--- a/src/main/java/com/ppu/ppu/auth/controller/AuthController.java
+++ b/src/main/java/com/ppu/ppu/auth/controller/AuthController.java
@@ -36,18 +36,18 @@ public class AuthController {
         return ResponseEntity.ok(authService.loginPw(user));
     }
 
-//    @GetMapping("/login/kakao")
-//    public ResponseEntity<Void> kakaoLogin() {
-//        String uri = oAuthService.getKakaoLoginAuthorizeUrl();
-//        return ResponseEntity.status(302)
-//                .location(URI.create(uri))
-//                .build();
-//    }
+    @GetMapping("/login/kakao")
+    public ResponseEntity<Void> kakaoLogin() {
+        String uri = oAuthService.getKakaoLoginAuthorizeUrl();
+        return ResponseEntity.status(302)
+                .location(URI.create(uri))
+                .build();
+    }
 
-//    @GetMapping("/login/kakao/callback")
-//    public ResponseEntity<UserLoginResponseDto> kakaoLoginCallback(@Valid @ModelAttribute KakaoUserAuthorizeCodeDto dto) {
-//        return ResponseEntity.ok(oAuthService.kakaoLogin(dto));
-//    }
+    @GetMapping("/login/kakao/callback")
+    public ResponseEntity<UserLoginResponseDto> kakaoLoginCallback(@Valid @ModelAttribute KakaoUserAuthorizeCodeDto dto) {
+        return ResponseEntity.ok(oAuthService.kakaoLogin(dto));
+    }
 
     @PostMapping("/refresh")
     public ResponseEntity<UserRefreshResponseDto> refresh(@Valid @RequestBody UserRefreshDto dto) {
@@ -59,9 +59,9 @@ public class AuthController {
         return withdrawService.withdrawPreHandler(request);
     }
 
-//    @GetMapping("/withdraw/kakao/callback")
-//    public ResponseEntity<Void> kakaoWithdrawCallback(@Valid @ModelAttribute KakaoUserAuthorizeCodeDto dto) {
-//        withdrawService.withdrawKakao(dto);
-//        return ResponseEntity.noContent().build();
-//    }
+    @GetMapping("/withdraw/kakao/callback")
+    public ResponseEntity<Void> kakaoWithdrawCallback(@Valid @ModelAttribute KakaoUserAuthorizeCodeDto dto) {
+        withdrawService.withdrawKakao(dto);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/ppu/ppu/auth/service/OAuthService.java
+++ b/src/main/java/com/ppu/ppu/auth/service/OAuthService.java
@@ -21,24 +21,24 @@ public class OAuthService {
     private final KakaoUtil kakaoUtil;
     private final AuthService authService;
 
-//    public String getKakaoLoginAuthorizeUrl() {
-//        return kakaoUtil.buildAuthorizeUrl(KakaoAuthPurpose.LOGIN);
-//    }
-//
-//    public String getKakaoWithdrawAuthorizeUrl() {
-//        return kakaoUtil.buildAuthorizeUrl(KakaoAuthPurpose.WITHDRAW);
-//    }
-//
-//    public UserLoginResponseDto kakaoLogin(KakaoUserAuthorizeCodeDto dto) {
-//        KakaoOauthInfo info = kakaoUtil.requestKakaoOauthInfo(dto, KakaoAuthPurpose.LOGIN);
-//        return authService.loginOauth(mapFromKakaoToUserDto(info));
-//    }
-//
-//    public UserOauthDto kakaoWithdraw(KakaoUserAuthorizeCodeDto dto) {
-//        KakaoOauthInfo info = kakaoUtil.requestKakaoOauthInfo(dto, KakaoAuthPurpose.WITHDRAW);
-//        kakaoUtil.requestUserUnlink(info.getAccessToken());
-//        return mapFromKakaoToUserDto(info);
-//    }
+    public String getKakaoLoginAuthorizeUrl() {
+        return kakaoUtil.buildAuthorizeUrl(KakaoAuthPurpose.LOGIN);
+    }
+
+    public String getKakaoWithdrawAuthorizeUrl() {
+        return kakaoUtil.buildAuthorizeUrl(KakaoAuthPurpose.WITHDRAW);
+    }
+
+    public UserLoginResponseDto kakaoLogin(KakaoUserAuthorizeCodeDto dto) {
+        KakaoOauthInfo info = kakaoUtil.requestKakaoOauthInfo(dto, KakaoAuthPurpose.LOGIN);
+        return authService.loginOauth(mapFromKakaoToUserDto(info));
+    }
+
+    public UserOauthDto kakaoWithdraw(KakaoUserAuthorizeCodeDto dto) {
+        KakaoOauthInfo info = kakaoUtil.requestKakaoOauthInfo(dto, KakaoAuthPurpose.WITHDRAW);
+        kakaoUtil.requestUserUnlink(info.getAccessToken());
+        return mapFromKakaoToUserDto(info);
+    }
 
     private UserOauthDto mapFromKakaoToUserDto(KakaoOauthInfo dto) {
         var profile = dto.getProfile().getKakaoAccount();

--- a/src/main/java/com/ppu/ppu/auth/service/WithdrawService.java
+++ b/src/main/java/com/ppu/ppu/auth/service/WithdrawService.java
@@ -32,19 +32,19 @@ public class WithdrawService {
                 userService.deleteUser(userId);
                 yield ResponseEntity.noContent().build();
             }
-//            case KAKAO -> ResponseEntity.status(HttpStatus.FOUND)
-//                    .location(URI.create(oAuthService.getKakaoWithdrawAuthorizeUrl()))
-//                    .build();
+            case KAKAO -> ResponseEntity.status(HttpStatus.FOUND)
+                    .location(URI.create(oAuthService.getKakaoWithdrawAuthorizeUrl()))
+                    .build();
             default -> throw new AuthException(ErrorCode.AUTH_INVALID_TOKEN);
         };
     }
 
-//    public void withdrawKakao(KakaoUserAuthorizeCodeDto dto) {
-//        UserOauthDto oauthDto = oAuthService.kakaoWithdraw(dto);
-//        User user = userService.getUserByEmailAndLoginType(oauthDto.getEmail(), oauthDto.getLoginType())
-//                .orElseThrow(() -> new AuthException(ErrorCode.AUTH_INVALID_TOKEN));
-//
-//        UUID userId = user.getId();
-//        userService.deleteUser(userId);
-//    }
+    public void withdrawKakao(KakaoUserAuthorizeCodeDto dto) {
+        UserOauthDto oauthDto = oAuthService.kakaoWithdraw(dto);
+        User user = userService.getUserByEmailAndLoginType(oauthDto.getEmail(), oauthDto.getLoginType())
+                .orElseThrow(() -> new AuthException(ErrorCode.AUTH_INVALID_TOKEN));
+
+        UUID userId = user.getId();
+        userService.deleteUser(userId);
+    }
 }

--- a/src/main/java/com/ppu/ppu/config/SwaggerConfig.java
+++ b/src/main/java/com/ppu/ppu/config/SwaggerConfig.java
@@ -1,18 +1,33 @@
 package com.ppu.ppu.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 
 @Configuration
 public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("PPU API")
+                .version("0.0.1")
+                .description("PPU API 문서입니다.");
+        SecurityRequirement sr = new SecurityRequirement().addList("Auth");
+        Components components = new Components()
+                .addSecuritySchemes("Auth", new SecurityScheme()
+                        .name("Auth")
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
         return new OpenAPI()
-                .info(new Info()
-                        .title("PPU API")
-                        .version("v1"));
+                .info(info)
+                .addSecurityItem(sr)
+                .components(components);
     }
 }

--- a/src/main/java/com/ppu/ppu/config/WebConfig.java
+++ b/src/main/java/com/ppu/ppu/config/WebConfig.java
@@ -20,7 +20,9 @@ public class WebConfig implements WebMvcConfigurer {
                         "/auth/login/**",
                         "/auth/signup",
                         "/auth/refresh",
-                        "/auth/withdraw/*/callback"
+                        "/auth/withdraw/*/callback",
+                        "/v3/api-docs/**",
+                        "/swagger-ui/**"
                 );
     }
 }

--- a/src/main/java/com/ppu/ppu/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/ppu/ppu/interceptor/AuthInterceptor.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-//swagger 사용으로 인한 일시 비활성화
 @Component
 public class AuthInterceptor implements HandlerInterceptor {
     private final JwtUtil jwtUtil;
@@ -17,17 +16,17 @@ public class AuthInterceptor implements HandlerInterceptor {
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
-//        String authorization = request.getHeader("Authorization");
-//        if (authorization == null) {
-//            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
-//            return false;
-//        }
-//        String accessToken = authorization.split(" ")[1];
-//        if(! jwtUtil.validateToken(accessToken)) {
-//            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
-//            return false;
-//        }
-//        request.setAttribute("id" , jwtUtil.parseToken(accessToken));
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+            return false;
+        }
+        String accessToken = authorization.split(" ")[1];
+        if(! jwtUtil.validateToken(accessToken)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+            return false;
+        }
+        request.setAttribute("id" , jwtUtil.parseToken(accessToken));
         return true;
     }
 }

--- a/src/main/java/com/ppu/ppu/perfume/PerfumeController.java
+++ b/src/main/java/com/ppu/ppu/perfume/PerfumeController.java
@@ -19,7 +19,7 @@ public class PerfumeController {
         this.perfumeService = perfumeService;
     }
 
-    @GetMapping("/")
+    @GetMapping("")
     public ResponseEntity<List<PerfumeResponseDto>> getAllPerfumes() {
         return ResponseEntity.ok(perfumeService.getAllPerfumes());
         //TODO 페이지네이션

--- a/src/main/java/com/ppu/ppu/utils/kakao/KakaoConfig.java
+++ b/src/main/java/com/ppu/ppu/utils/kakao/KakaoConfig.java
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-//import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @Getter
@@ -19,19 +19,19 @@ public class KakaoConfig {
         CLIENT_ID = System.getenv("KAKAO_REST_API_KEY");
     }
 
-//    @Bean
-//    public WebClient kakaoAuthClient(WebClient.Builder builder) {
-//        return builder
-//                .baseUrl(KAKAO_AUTH_URI)
-//                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-//                .build();
-//    }
-//
-//    @Bean
-//    public WebClient kakaoApiClient(WebClient.Builder builder) {
-//        return builder
-//                .baseUrl(KAKAO_API_URI)
-//                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-//                .build();
-//    }
+    @Bean
+    public WebClient kakaoAuthClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl(KAKAO_AUTH_URI)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Bean
+    public WebClient kakaoApiClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl(KAKAO_API_URI)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
 }

--- a/src/main/java/com/ppu/ppu/utils/kakao/KakaoUtil.java
+++ b/src/main/java/com/ppu/ppu/utils/kakao/KakaoUtil.java
@@ -6,84 +6,84 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-//import org.springframework.web.reactive.function.BodyInserters;
-//import org.springframework.web.reactive.function.client.WebClient;
-//import org.springframework.web.util.UriComponentsBuilder;
-//import reactor.core.publisher.Mono;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
 
 @Component
 @RequiredArgsConstructor
 public class KakaoUtil {
     private final KakaoConfig kakaoConfig;
-//    private final WebClient kakaoAuthClient;
-//    private final WebClient kakaoApiClient;
-//
-//    public String buildAuthorizeUrl(KakaoAuthPurpose purpose) {
-//        return UriComponentsBuilder
-//                .fromUriString(kakaoConfig.getKAKAO_AUTH_URI())
-//                .path("/oauth/authorize")
-//                .queryParam("client_id", kakaoConfig.getCLIENT_ID())
-//                .queryParam("redirect_uri", purpose.getRedirectUri())
-//                .queryParam("response_type", "code")
-//                .toUriString();
-//    }
-//
-//    public KakaoOauthInfo requestKakaoOauthInfo(KakaoUserAuthorizeCodeDto dto, KakaoAuthPurpose purpose) {
-//        String code = dto.getCode();
-//
-//        KakaoUserAccessTokenDto token = requestToken(code, purpose);
-//        KakaoUserProfileDto profile = requestUserProfile(token.getAccess_token());
-//
-//        return new KakaoOauthInfo(token.getAccess_token(), profile);
-//    }
-//
-//    private KakaoUserAccessTokenDto requestToken(String code, KakaoAuthPurpose purpose) {
-//        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-//        params.add("grant_type", "authorization_code");
-//        params.add("client_id", kakaoConfig.getCLIENT_ID());
-//        params.add("redirect_uri", purpose.getRedirectUri());
-//        params.add("code", code);
-//
-//        return kakaoAuthClient.post()
-//                .uri("/oauth/token")
-//                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-//                .body(BodyInserters.fromFormData(params))
-//                .retrieve()
-//                .onStatus(
-//                        status -> status.is4xxClientError() || status.is5xxServerError(),
-//                        clientResponse -> clientResponse.bodyToMono(String.class)
-//                                .flatMap(errorBody -> {
-//                                    System.err.println("Error response from Kakao: " + errorBody);
-//                                    return Mono.error(new RuntimeException("Kakao token request failed: " + errorBody));
-//                                })
-//                )
-//                .bodyToMono(KakaoUserAccessTokenDto.class)
-//                .block();
-//    }
-//
-//    private KakaoUserProfileDto requestUserProfile(String kakaoAccessToken) {
-//        return kakaoApiClient.get()
-//                .uri("/v2/user/me")
-//                .header("Authorization", "Bearer " + kakaoAccessToken)
-//                .retrieve()
-//                .onStatus(
-//                        status -> status.is4xxClientError() || status.is5xxServerError(),
-//                        clientResponse -> clientResponse.bodyToMono(String.class)
-//                                .flatMap(errorBody -> {
-//                                    System.err.println("Error response from Kakao: " + errorBody);
-//                                    return Mono.error(new RuntimeException("Kakao token request failed: " + errorBody));
-//                                })
-//                )
-//                .bodyToMono(KakaoUserProfileDto.class)
-//                .block();
-//    }
-//
-//    public KakaoUserUnlinkDto requestUserUnlink(String kakaoAccessToken) {
-//        return kakaoApiClient.post()
-//                .uri("/v1/user/unlink")
-//                .header("Authorization", "Bearer " + kakaoAccessToken)
-//                .retrieve()
-//                .bodyToMono(KakaoUserUnlinkDto.class)
-//                .block();
-//    }
+    private final WebClient kakaoAuthClient;
+    private final WebClient kakaoApiClient;
+
+    public String buildAuthorizeUrl(KakaoAuthPurpose purpose) {
+        return UriComponentsBuilder
+                .fromUriString(kakaoConfig.getKAKAO_AUTH_URI())
+                .path("/oauth/authorize")
+                .queryParam("client_id", kakaoConfig.getCLIENT_ID())
+                .queryParam("redirect_uri", purpose.getRedirectUri())
+                .queryParam("response_type", "code")
+                .toUriString();
+    }
+
+    public KakaoOauthInfo requestKakaoOauthInfo(KakaoUserAuthorizeCodeDto dto, KakaoAuthPurpose purpose) {
+        String code = dto.getCode();
+
+        KakaoUserAccessTokenDto token = requestToken(code, purpose);
+        KakaoUserProfileDto profile = requestUserProfile(token.getAccess_token());
+
+        return new KakaoOauthInfo(token.getAccess_token(), profile);
+    }
+
+    private KakaoUserAccessTokenDto requestToken(String code, KakaoAuthPurpose purpose) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoConfig.getCLIENT_ID());
+        params.add("redirect_uri", purpose.getRedirectUri());
+        params.add("code", code);
+
+        return kakaoAuthClient.post()
+                .uri("/oauth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(params))
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    System.err.println("Error response from Kakao: " + errorBody);
+                                    return Mono.error(new RuntimeException("Kakao token request failed: " + errorBody));
+                                })
+                )
+                .bodyToMono(KakaoUserAccessTokenDto.class)
+                .block();
+    }
+
+    private KakaoUserProfileDto requestUserProfile(String kakaoAccessToken) {
+        return kakaoApiClient.get()
+                .uri("/v2/user/me")
+                .header("Authorization", "Bearer " + kakaoAccessToken)
+                .retrieve()
+                .onStatus(
+                        status -> status.is4xxClientError() || status.is5xxServerError(),
+                        clientResponse -> clientResponse.bodyToMono(String.class)
+                                .flatMap(errorBody -> {
+                                    System.err.println("Error response from Kakao: " + errorBody);
+                                    return Mono.error(new RuntimeException("Kakao token request failed: " + errorBody));
+                                })
+                )
+                .bodyToMono(KakaoUserProfileDto.class)
+                .block();
+    }
+
+    public KakaoUserUnlinkDto requestUserUnlink(String kakaoAccessToken) {
+        return kakaoApiClient.post()
+                .uri("/v1/user/unlink")
+                .header("Authorization", "Bearer " + kakaoAccessToken)
+                .retrieve()
+                .bodyToMono(KakaoUserUnlinkDto.class)
+                .block();
+    }
 }


### PR DESCRIPTION
## 👩🏻‍💻 작업 내용
### auth 활성화
- swagger 활성화 먼저 빨리 처리하고 테스트 하기 위해 비활성화했던 auth 관련 API 및 미들웨어를 다시 활성화했습니다.
- swagger에서 헤더에 토큰 넣을 수 있도록 활성화 해두었습니다.
### 카카오 로그인 주석 복원
- KakaoUtil 쪽에서 사용중이던 spring webflux 패키지가 swagger와 의존성 충돌 문제가 있다고 생각해서 비활성화 했었는데, 잘 되는것 확인하고 다시 활성화했습니다.
- Spring Boot 버전 변경
- Spring Boot 3.4.2(기존)의 경우 springdoc 2.8 이상 사용이 필요합니다. 
  급하게 작업하느라 Spring Boot 3.3.2로 내리고 springdoc 2.5.0을 사용하였는데, Spring Boot 버전을 복원하고 springdoc을 버전 업 하였습니다.
### Dockerfile 및 docker compose 스크립트 대폭 수정
- 저번에 계속 말씀해주셨던 서버에 신규 이미지 반영 안되는 문제... 아직도 계속되고 있었습니다.
  swagger 연동 반영이 서버에서 계속 안되길래 docker 이미지 문제로 생각하고 Dockerfile을 야금야금 고쳐버려서..ㅎ 일단은 건든 김에 바꾼대로 두었습니다.
- 별개로 신규 반영이 안되는 문제는 image pull policy 설정값이 동작을 안하고 있어서 그랬습니다. `docker-compose`는 버전 1.X이고, `docker compose`가 버전 `2.X`인데 `1.X`에서는 image pull policy 설정이 반영이 안된다더라구요... 서버에 `docker compose`로 버전업 해두었고, actions script의 cli도 `docker-compose ...` 대신에 `docker compose ...` 로 변경해서 문제 해결했습니다.
  로컬에선 문제 없었던 이유가 pull 해오는 방식이 아니어서 그랬던 것 같네요!
- 로컬에서 작업할 때 매번 빌드를 새로 하는게 불편한 듯 해서, `jar` 파일 만들어서 실행하는 방법 대신 `bootRun + devTools`로 로컬에 컨테이너와 볼륨 설정하는 방식으로 변경해봤습니다.
  최초 한 번 빌드해놓으면 수정사항 바로 반영돼서 컨테이너 올렸다 내렸다 안해도 됩니다! (핫 리로드)
  인텔리제이 설정 건드려주셔야 하는 부분이 있어서 최초 1회 반영하고 작업하시면 됩니다.
  `Preferences → Build, Execution, Deployment → Compiler → Build project automatically 체크`

<!-- ## 📸 스크린샷

- |기능|스크린샷|

|:--:|:--:|
|기능이름|스크린샷 첨부| -->

## 🔍 참고 사항
-  slim 이미지로 서버 환경에 배포 잘 되는지 확인하고 문제 있으면 hotfix 진행하겠습니다!
- 이해 안되시는 부분은 코멘트 주세요!

## 🔘 관련 이슈
- close #